### PR TITLE
Transfer scope owner to contract on create ask

### DIFF
--- a/schema/execute_msg.json
+++ b/schema/execute_msg.json
@@ -63,6 +63,12 @@
               "items": {
                 "$ref": "#/definitions/Coin"
               }
+            },
+            "scope_address": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           }
         }
@@ -83,10 +89,7 @@
           ],
           "properties": {
             "base": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/Coin"
-              }
+              "$ref": "#/definitions/BaseType"
             },
             "effective_time": {
               "anyOf": [
@@ -132,6 +135,53 @@
     }
   ],
   "definitions": {
+    "BaseType": {
+      "anyOf": [
+        {
+          "type": "object",
+          "required": [
+            "Coin"
+          ],
+          "properties": {
+            "Coin": {
+              "type": "object",
+              "required": [
+                "coins"
+              ],
+              "properties": {
+                "coins": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/Coin"
+                  }
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Scope"
+          ],
+          "properties": {
+            "Scope": {
+              "type": "object",
+              "required": [
+                "scope_address"
+              ],
+              "properties": {
+                "scope_address": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
     "Coin": {
       "type": "object",
       "required": [

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -432,7 +432,7 @@ fn replace_scope_owner(
     scope.owners = scope
         .owners
         .into_iter()
-        .filter(|owner| owner.role == PartyType::Owner)
+        .filter(|owner| owner.role != PartyType::Owner)
         .collect();
     // Append the target value as the new sole owner
     scope.owners.push(Party {
@@ -755,8 +755,50 @@ mod tests {
             Ok(response) => {
                 assert_eq!(response.attributes.len(), 1);
                 assert_eq!(response.attributes[0], attr("action", "create_ask"));
-                // TODO: Inspect the contents of the message once they're available as public exports from provwasm
                 assert_eq!(response.messages.len(), 1);
+                // TODO: Uncomment this set of checks once the values are exposed in provwasm for it to compile
+                // match response.messages.first().unwrap().msg {
+                //     CosmosMsg::Custom(ProvenanceMsg {
+                //         params:
+                //             ProvenanceMsgParams::Metadata(
+                //                 provwasm_std::msg::MetadataMsgParams::WriteScope { scope, signers },
+                //             ),
+                //         ..
+                //     }) => {
+                //         assert_eq!(
+                //             1,
+                //             scope.owners.len(),
+                //             "expected the scope to only include one owner after the owner was changed to the contract",
+                //         );
+                //         let scope_owner = scope.owners.first().unwrap();
+                //         assert_eq!(
+                //             MOCK_CONTRACT_ADDR,
+                //             scope_owner.address.as_str(),
+                //             "expected the contract address to be set as the scope owner",
+                //         );
+                //         assert_eq!(
+                //             PartyType::Owner,
+                //             scope_owner.role,
+                //             "expected the contract's role to be that of owner",
+                //         );
+                //         assert_eq!(
+                //             MOCK_CONTRACT_ADDR,
+                //             scope.value_owner_address.as_str(),
+                //             "expected the contract to remain the value owner on the scope",
+                //         );
+                //         assert_eq!(
+                //             1,
+                //             signers.len(),
+                //             "expected only a single signer to be used on the write scope request",
+                //         );
+                //         assert_eq!(
+                //             MOCK_CONTRACT_ADDR,
+                //             signers.first().unwrap().as_str(),
+                //             "expected the signer for the write scope request to be the contract",
+                //         );
+                //     }
+                //     msg => panic!("unexpected message emitted by create ask: {:?}", msg),
+                // };
             }
             Err(error) => {
                 panic!("failed to create ask: {:?}", error)

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -715,6 +715,8 @@ mod tests {
             Ok(response) => {
                 assert_eq!(response.attributes.len(), 1);
                 assert_eq!(response.attributes[0], attr("action", "create_ask"));
+                // TODO: Inspect the contents of the message once they're available as public exports from provwasm
+                assert_eq!(response.messages.len(), 1);
             }
             Err(error) => {
                 panic!("failed to create ask: {:?}", error)

--- a/src/error.rs
+++ b/src/error.rs
@@ -18,8 +18,11 @@ pub enum ContractError {
     #[error("Scope ask base cannot also be sent funds")]
     ScopeAskBaseWithFunds,
 
-    #[error("Coin ask base can only be created from funds provided")]
-    CoinAskBaseWithoutFunds,
+    #[error("Scope at address [{scope_address}] has invalid owner: {explanation}")]
+    InvalidScopeOwner {
+        scope_address: String,
+        explanation: String,
+    },
 
     #[error("Missing field: {field:?}")]
     MissingField { field: String },

--- a/src/msg.rs
+++ b/src/msg.rs
@@ -22,7 +22,7 @@ pub enum ExecuteMsg {
     CreateAsk {
         id: String,
         quote: Vec<Coin>,
-        base: Option<BaseType>,
+        scope_address: Option<String>,
     },
     CreateBid {
         id: String,

--- a/src/state.rs
+++ b/src/state.rs
@@ -74,7 +74,7 @@ impl BaseType {
                     coins: coins.to_vec(),
                 }
             }
-            BaseType::Scope { scope_address } => self.to_owned(),
+            BaseType::Scope { .. } => self.to_owned(),
         }
     }
 }


### PR DESCRIPTION
Made a few changes to the core branch with this one:
- Swapped the requirement of a `BaseType` to just an `Option<String>` for providing a scope address.  IMO allowing base type on the ask portion just increases the likelihood of confusion from callers because they might think the `Coin` piece is something they can do
- Validates that the scope is properly-formed (value-owned beforehand by contract, and owned by the sender)
- Adds a helper function to swap out scope ownership based on various params, which will be used for other functionality as we keep going (facilitating withdraws, transfering when matched, etc)