### PR TITLE
Mandate that scope is fully owned by contract when accepted as input

### DIFF
--- a/src/msg.rs
+++ b/src/msg.rs
@@ -42,3 +42,9 @@ pub enum QueryMsg {
     GetBid { id: String },
     GetContractInfo {},
 }
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum MigrateMsg {
+    NewVersion {},
+}

--- a/src/state.rs
+++ b/src/state.rs
@@ -42,6 +42,7 @@ pub static NAMESPACE_ORDER_ASK_V2: &[u8] = b"ask_v2";
 pub static NAMESPACE_ORDER_BID_V2: &[u8] = b"bid_v2";
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
 pub enum BaseType {
     Coin { coins: Vec<Coin> },
     Scope { scope_address: String },


### PR DESCRIPTION
This swaps the code to not do any scope operations on create ask.  The code simply verifies now that the scope is entirely owned by the contract before boarding, which allows the other operations to have fully control while it's being asked upon.

This also adds a really basic migration route in prep for when migrations will move the original contract to v2 (if that's a thing that happens)